### PR TITLE
Updated database.py to read from my.cnf

### DIFF
--- a/frappe/database.py
+++ b/frappe/database.py
@@ -50,7 +50,7 @@ class Database:
 		"""Connects to a database as set in `site_config.json`."""
 		warnings.filterwarnings('ignore', category=MySQLdb.Warning)
 		self._conn = MySQLdb.connect(user=self.user, host=self.host, passwd=self.password,
-			use_unicode=True, charset='utf8mb4')
+			use_unicode=True, charset='utf8mb4', read_default_file="/etc/mysql/my.cnf")
 		self._conn.converter[246]=float
 		self._conn.converter[12]=get_datetime
 		self._conn.encoders[UnicodeWithAttrs] = self._conn.encoders[UnicodeType]


### PR DESCRIPTION
This is a simple fix for when MariaDB is configured to use a socket file other than /tmp/mysql.sock. 

I run into this problem with a new ERPNext installation on a Ubuntu 16.04 LTS machine. When issuing `bench new-site localhost` I was receiving the error "Can't connect to local MySQL server through socket '/tmp/mysql.sock' (2)".

This happens because the MariaDB server is (correctly) using /var/run/mysqld/mysqld.sock (as configured in /etc/mysql/my.cnf) instead of /tmp/mysql.sock (the default value).

One simple workaround wold be to create a symbolic link, but the real problem is that while MariaDB is reading the my.cnf file, ERPNext/Frappe isn't. This patch works for me, but the my.cnf configuration file can be found in different paths, according to [table 5.2 of MySQL manual - Using Option Files](https://dev.mysql.com/doc/refman/5.7/en/option-files.html).

For more details, see [Can’t connect to local MySQL server through socket ‘/tmp/mysql.sock’](https://discuss.erpnext.com/t/fixed-cant-connect-to-local-mysql-server-through-socket-tmp-mysql-sock/20979)